### PR TITLE
fix(Activation): LightController.Result no longer throws when Logger wasn't initialized

### DIFF
--- a/src/Liquid.Activation/Controller/LightController.cs
+++ b/src/Liquid.Activation/Controller/LightController.cs
@@ -69,7 +69,7 @@ namespace Liquid.Activation
         {
             response.PayLoad = (response.ViewModelData != null) ? response.ViewModelData.ToJsonCamelCase() : null;
 
-            if (Logger.EnabledLogTrafic)
+            if (Logger?.EnabledLogTrafic == true)
             {
                 Logger.Info("Router: " + HttpContext.Request.Path + " \n Response: " + response.ToStringCamelCase());
             }


### PR DESCRIPTION
Closes #18.