### PR TITLE
fix: change package name

### DIFF
--- a/src/Liquid.Base/Liquid.Base.csproj
+++ b/src/Liquid.Base/Liquid.Base.csproj
@@ -10,7 +10,6 @@
     <Copyright>Avanade Inc.</Copyright>
     <Description>Main abstractions for building Liquid Microservices.</Description>
     <Authors>Avanade Brazil Architect Team - Gustavo Denis; Leonardo Machado; Andersson Pinheiro; Paulo Araujo</Authors>
-    <PackageId>Liquid.Base</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Liquid.OnPre/Liquid.OnPre.csproj
+++ b/src/Liquid.OnPre/Liquid.OnPre.csproj
@@ -35,6 +35,11 @@
     <ProjectReference Include="..\Liquid.Runtime\Liquid.Runtime.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Folder Include="Hubs\" />
+    <Folder Include="Storages\" />
+    <Folder Include="Telemetry\" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.3" />
     <PackageReference Include="System.Runtime.Caching" Version="4.6.0-preview6.19303.8" />
   </ItemGroup>


### PR DESCRIPTION
Liquid.Base package name was wrong as a result of a duplicated element in the csproj. That was removed.