### PR TITLE
fix: handles null configuration key

### DIFF
--- a/Liquid.All.sln
+++ b/Liquid.All.sln
@@ -1,4 +1,5 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29215.179
 MinimumVisualStudioVersion = 10.0.40219.1


### PR DESCRIPTION
AddTelemetry now properly handles the result of the section being null.
Also did some improvements like not searching the section twice, and being relaxed in finding the section (as we are with comparing the value of the section).

Closes #69.