### PR TITLE
fix: always generate docs for the sample project

### DIFF
--- a/samples/Liquid.Sample.CarRegistry/Liquid.Sample.CarRegistry.csproj
+++ b/samples/Liquid.Sample.CarRegistry/Liquid.Sample.CarRegistry.csproj
@@ -10,8 +10,8 @@
     <AssemblyName>Liquid.Sample.CarRegistry</AssemblyName>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netcoreapp2.2\Sample.Car.xml</DocumentationFile>
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is required because the swagger integration is configured to always extract descriptions/schemas from the generated documentation file. When this file does't exist, we get a FileNotFoundException at the startup phase.

https://github.com/Avanade/Liquid-Application-Framework/blob/8b42d048fecbb379498274caa55d12fd351e8acd/src/Liquid.Runtime/OpenApi/Swagger.cs#L118-L122