### PR TITLE
feat(LightTelemetry): adds TrackException to interface

### DIFF
--- a/src/Liquid.Base/Interfaces/Telemetry/ILightTelemetry.cs
+++ b/src/Liquid.Base/Interfaces/Telemetry/ILightTelemetry.cs
@@ -1,7 +1,13 @@
-﻿using Liquid.Base.Interfaces;
+﻿// Copyright (c) Avanade Inc. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
 
 namespace Liquid.Interfaces
 {
+    /// <summary>
+    /// Service that enables observability for implementers and Liquid itself.
+    /// </summary>
     public interface ILightTelemetry : IWorkbenchService
     {
         void TrackTrace(params object[] trace);
@@ -10,7 +16,13 @@ namespace Liquid.Interfaces
         void ComputeMetric(string metricLabel, double value);
         void BeginMetricComputation(string metricLabel);
         void EndMetricComputation(string metricLabel);
-        void EnqueueContext(string parentID, object value = null, string operationID = "");        
+        void EnqueueContext(string parentID, object value = null, string operationID = "");
         void DequeueContext();
+
+        /// <summary>
+        /// Captures an exception in the telemetry provider.
+        /// </summary>
+        /// <param name="exception">The exception to be captured.</param>
+        void TrackException(Exception exception);
     }
 }

--- a/src/Liquid.OnAWS/MessageBuses/AwsSqsSns.cs
+++ b/src/Liquid.OnAWS/MessageBuses/AwsSqsSns.cs
@@ -99,7 +99,7 @@ namespace Liquid.OnAWS
                         catch (Exception exRegister)
                         {
                             //Use the class instead of interface because tracking exceptions directly is not supposed to be done outside AMAW (i.e. by the business code)
-                            ((LightTelemetry)Workbench.Instance.Telemetry).TrackException(exRegister);
+                            Workbench.Instance.Telemetry.TrackException(exRegister);
                         }
                     }
                 }
@@ -107,7 +107,7 @@ namespace Liquid.OnAWS
             catch (Exception exception)
             {
                 //Use the class instead of interface because tracking exceptions directly is not supposed to be done outside AMAW (i.e. by the business code)
-                ((LightTelemetry)Workbench.Instance.Telemetry).TrackException(exception);
+                Workbench.Instance.Telemetry.TrackException(exception);
             }
         }
         /// <summary>
@@ -158,7 +158,7 @@ namespace Liquid.OnAWS
                         catch (Exception exRegister)
                         {
                             //Use the class instead of interface because tracking exceptions directly is not supposed to be done outside AMAW (i.e. by the business code)
-                            ((LightTelemetry)Workbench.Instance.Telemetry).TrackException(exRegister);
+                            Workbench.Instance.Telemetry.TrackException(exRegister);
                         }
                     }
                 }
@@ -166,7 +166,7 @@ namespace Liquid.OnAWS
             catch (Exception exception)
             {
                 //Use the class instead of interface because tracking exceptions directly is not supposed to be done outside AMAW (i.e. by the business code)
-                ((LightTelemetry)Workbench.Instance.Telemetry).TrackException(exception);
+                Workbench.Instance.Telemetry.TrackException(exception);
             }
         }
 

--- a/src/Liquid.OnAzure/Databases/CosmosDB.cs
+++ b/src/Liquid.OnAzure/Databases/CosmosDB.cs
@@ -321,7 +321,7 @@ namespace Liquid.OnAzure
                 }
                 catch (Exception exRegister)
                 {
-                    ((LightTelemetry)Workbench.Instance.Telemetry).TrackException(exRegister);
+                    Workbench.Instance.Telemetry.TrackException(exRegister);
                     errorEntities.Add(model);
                 }
             }

--- a/src/Liquid.OnAzure/Hubs/EventHub.cs
+++ b/src/Liquid.OnAzure/Hubs/EventHub.cs
@@ -58,7 +58,7 @@ namespace Liquid.OnAzure.Hubs
         public Task ExceptionReceivedHandler(ExceptionReceivedEventArgs exceptionReceivedEventArgs)
         {
             //Use the class instead of interface because tracking exceptions directly is not supposed to be done outside AMAW (i.e. by the business code)
-            ((LightTelemetry)Workbench.Instance.Telemetry).TrackException(exceptionReceivedEventArgs.Exception);
+            Workbench.Instance.Telemetry.TrackException(exceptionReceivedEventArgs.Exception);
             return Task.CompletedTask;
         }
 
@@ -104,7 +104,7 @@ namespace Liquid.OnAzure.Hubs
                 Exception moreInfo = new Exception($"Exception reading topic={topic.Value.TopicName} with subscription={topic.Value.Subscription} from event hub. See inner exception for details. Message={exception.Message}", exception);
 
                 //Use the class instead of interface because tracking exceptions directly is not supposed to be done outside AMAW (i.e. by the business code)
-                ((LightTelemetry)Workbench.Instance.Telemetry).TrackException(moreInfo);
+                Workbench.Instance.Telemetry.TrackException(moreInfo);
             }
         }
 

--- a/src/Liquid.OnAzure/MessageBuses/ServiceBus.cs
+++ b/src/Liquid.OnAzure/MessageBuses/ServiceBus.cs
@@ -60,7 +60,7 @@ namespace Liquid.OnAzure
         public Task ExceptionReceivedHandler(ExceptionReceivedEventArgs exceptionReceivedEventArgs)
         {
             //Use the class instead of interface because tracking exceptions directly is not supposed to be done outside AMAW (i.e. by the business code)
-            ((LightTelemetry)Workbench.Instance.Telemetry).TrackException(exceptionReceivedEventArgs.Exception);
+            Workbench.Instance.Telemetry.TrackException(exceptionReceivedEventArgs.Exception);
             return Task.CompletedTask;
         }
 
@@ -96,7 +96,7 @@ namespace Liquid.OnAzure
                             {
                                 Exception moreInfo = new Exception($"Exception reading message from queue {queueName}. See inner exception for details. Message={exRegister.Message}", exRegister);
                                 //Use the class instead of interface because tracking exceptions directly is not supposed to be done outside AMAW (i.e. by the business code)
-                                ((LightTelemetry)Workbench.Instance.Telemetry).TrackException(moreInfo);
+                                Workbench.Instance.Telemetry.TrackException(moreInfo);
 
                                 //If there is a error , set DeadLetter on register
                                 if (queueReceiver.ReceiveMode == ReceiveMode.PeekLock)
@@ -114,7 +114,7 @@ namespace Liquid.OnAzure
             {
                 Exception moreInfo = new Exception($"Error setting up queue consumption from service bus. See inner exception for details. Message={exception.Message}", exception);
                 //Use the class instead of interface because tracking exceptions directly is not supposed to be done outside AMAW (i.e. by the business code)
-                ((LightTelemetry)Workbench.Instance.Telemetry).TrackException(moreInfo);
+                Workbench.Instance.Telemetry.TrackException(moreInfo);
             }
         }
 
@@ -155,7 +155,7 @@ namespace Liquid.OnAzure
                             {
                                 Exception moreInfo = new Exception($"Exception reading message from topic {topicName} and subscriptName {subscriptName}. See inner exception for details. Message={exRegister.Message}", exRegister);
                                 //Use the class instead of interface because tracking exceptions directly is not supposed to be done outside AMAW (i.e. by the business code)
-                                ((LightTelemetry)Workbench.Instance.Telemetry).TrackException(moreInfo);
+                                Workbench.Instance.Telemetry.TrackException(moreInfo);
 
                                 var exceptionDetails = $"{exRegister.Message}";
 
@@ -200,7 +200,7 @@ namespace Liquid.OnAzure
             {
                 Exception moreInfo = new Exception($"Error setting up subscription consumption from service bus. See inner exception for details. Message={exception.Message}", exception);
                 //Use the class instead of interface because tracking exceptions directly is not supposed to be done outside AMAW (i.e. by the business code)
-                ((LightTelemetry)Workbench.Instance.Telemetry).TrackException(moreInfo);
+                Workbench.Instance.Telemetry.TrackException(moreInfo);
             }
         }
 

--- a/src/Liquid.OnGoogle/MessageBuses/PubSub.cs
+++ b/src/Liquid.OnGoogle/MessageBuses/PubSub.cs
@@ -96,7 +96,7 @@ namespace Liquid.OnGoogle
                         catch (Exception exRegister)
                         {
                             //Use the class instead of interface because tracking exceptions directly is not supposed to be done outside AMAW (i.e. by the business code)
-                            ((LightTelemetry)Workbench.Instance.Telemetry).TrackException(exRegister);
+                            Workbench.Instance.Telemetry.TrackException(exRegister);
 
                             return await Task.FromResult<SubscriberClient.Reply>(SubscriberClient.Reply.Nack);
                         }                      
@@ -108,7 +108,7 @@ namespace Liquid.OnGoogle
             catch (Exception exception)
             {
                 //Use the class instead of interface because tracking exceptions directly is not supposed to be done outside AMAW (i.e. by the business code)
-                ((LightTelemetry)Workbench.Instance.Telemetry).TrackException(exception);
+                Workbench.Instance.Telemetry.TrackException(exception);
             }
         }
 

--- a/src/Liquid.OnPre/MessageBuses/MicrosoftMessageQueuing.cs
+++ b/src/Liquid.OnPre/MessageBuses/MicrosoftMessageQueuing.cs
@@ -73,7 +73,7 @@ namespace Liquid.OnWindowsClient
             {
                 Exception moreInfo = new Exception($"Error setting up queue consumption from service bus. See inner exception for details. Message={exception.Message}", exception);
                 //Use the class instead of interface because tracking exceptions directly is not supposed to be done outside AMAW (i.e. by the business code)
-                ((LightTelemetry)Workbench.Instance.Telemetry).TrackException(moreInfo);
+                Workbench.Instance.Telemetry.TrackException(moreInfo);
             }
         }
 
@@ -100,7 +100,7 @@ namespace Liquid.OnWindowsClient
             {
                 Exception moreInfo = new Exception($"Error setting up subscription consumption from service bus. See inner exception for details. Message={exception.Message}", exception);
                 //Use the class instead of interface because tracking exceptions directly is not supposed to be done outside AMAW (i.e. by the business code)
-                ((LightTelemetry)Workbench.Instance.Telemetry).TrackException(moreInfo);
+                Workbench.Instance.Telemetry.TrackException(moreInfo);
             }
         }
 

--- a/src/Liquid.Repository/LightRepository.cs
+++ b/src/Liquid.Repository/LightRepository.cs
@@ -490,7 +490,7 @@ namespace Liquid.Repository
             }
             catch (Exception exRegister)
             {
-                ((LightTelemetry)Workbench.Instance.Telemetry).TrackException(exRegister);
+                Workbench.Instance.Telemetry.TrackException(exRegister);
             }
 
             return Task.FromResult<T>(default(T));

--- a/src/Liquid.Runtime/Telemetry/LightTelemetryMiddleware.cs
+++ b/src/Liquid.Runtime/Telemetry/LightTelemetryMiddleware.cs
@@ -99,7 +99,7 @@ namespace Liquid.Runtime.Telemetry
             }
             catch (Exception e)
             {
-                ((LightTelemetry)Workbench.Instance.Telemetry).TrackException(e);
+                Workbench.Instance.Telemetry.TrackException(e);
                 throw;
             }
         }

--- a/test/Liquid.Base.Tests/WorkbenchTests.cs
+++ b/test/Liquid.Base.Tests/WorkbenchTests.cs
@@ -277,6 +277,11 @@ namespace Liquid.Base.Tests
                 throw new NotImplementedException();
             }
 
+            public void TrackException(Exception exception)
+            {
+                throw new NotImplementedException();
+            }
+
             public void TrackMetric(string metricLabel, double value)
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
ILightTelemetry lacked the TrackException method. This was done by design - to avoid consumer code to call TrackException, it seems, because exception handling was supposed to be done at framework level.

Our take is that this creates more problems than solves. Consumers will still be able to directly use LightTelemetry if they desire, or handle the exception and NOT call TrackException when they should.

Also, that meant a lot of violations of LSP in the framework code, and led to numerous issues during testing since it was impossible to mockout the LightTelemetry.TrackEvent dependency.

This commit adds the method and removes all LSP violations that I could find.

Closes #159.