### PR TITLE
Enhancement/remove source code has duplicate

### DIFF
--- a/src/Liquid.Domain/Localization/LocalizationConfig.cs
+++ b/src/Liquid.Domain/Localization/LocalizationConfig.cs
@@ -6,6 +6,7 @@ using FluentValidation;
 
 namespace Liquid.Domain.Localization
 {
+    [Obsolete("Prefer to use Liquid.Runtime \n This class will be removed in later version. Please refrain from accessing it.")]
     public class LocalizationConfig : LightConfig<LocalizationConfig>
     {
         public string DefaultCulture { get; set; }

--- a/test/Liquid.Runtime.Tests/LocalizationConfigurationTest.cs
+++ b/test/Liquid.Runtime.Tests/LocalizationConfigurationTest.cs
@@ -1,0 +1,37 @@
+using Xunit;
+
+namespace Liquid.Runtime.Tests
+{
+    public class LocalizationConfigurationTest    {
+        
+        [Fact]
+        public void WhenEnabledModuleShouldBeMandatory()
+        {
+            var configuration = new LocalizationConfig();
+         
+            configuration.Validate();
+            var results = configuration.Validator.Validate(configuration);
+
+            Assert.False(results.IsValid);
+            Assert.Contains(results.Errors,(value) => value == "A Default Culture should be defined.");
+        }
+
+ 
+        [Fact]
+        public void WhenEnabledValidationPass()
+        {
+            var configuration = new LocalizationConfig();
+            configuration.DefaultCulture = "pt-BR";
+            string[] cultures = new string[] { "en-US", "pt-BR" };
+            configuration.SupportedCultures = cultures;
+
+            configuration.Validate();
+
+            var results = configuration.Validator.Validate(configuration);
+
+            Assert.True(results.IsValid);
+            Assert.Empty(results.Errors);
+        }
+        
+    }
+}


### PR DESCRIPTION
@bruno-brant 
We have made the Liquid.Domain class obsolete because it will be removed in the future. We also implemented the tests. we look forward to your analysis.